### PR TITLE
feat: support Scala 3 and drop Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,13 +12,13 @@ organizationHomepage := Some(url("http://BahmanM.com"))
 ////////////////////////////////////////////////////////////////////////////////
 // build
 ////////////////////////////////////////////////////////////////////////////////
-scalaVersion := "2.13.3"
+scalaVersion := "2.13.11"
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "4.10.3" % "test"
+  "org.specs2" %% "specs2-core" % "4.20.0" % "test"
 )
 resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
 scalacOptions in Test ++= Seq("-Yrangepos")
-crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3")
+crossScalaVersions := Seq("2.12.18", "2.13.11", "3.3.0")
 
 ////////////////////////////////////////////////////////////////////////////////
 // sonatype and maven central

--- a/src/main/scala/com/bahmanm/persianutils/DateConverter.scala
+++ b/src/main/scala/com/bahmanm/persianutils/DateConverter.scala
@@ -44,10 +44,12 @@ object DateConverter {
         "year", "month", "day"
       )
       try {
-        val re(year, month, day) = date
-        new SimpleDate(year.toInt, month.toInt, day.toInt)
+        date match {
+          case re(year, month, day) =>
+            new SimpleDate(year.toInt, month.toInt, day.toInt)
+        }
       } catch {
-        case _ : Throwable =>
+        case _: Throwable =>
           throw new InvalidDateException()
       }
     }


### PR DESCRIPTION
This commit adds cross-compilation for Scala 3 and removes support for Scala 2.11. This is done to keep up with the latest Scala features and improve compatibility with other libraries.